### PR TITLE
Bugfixes - wrong variablename, adds SKU logic for retetention time

### DIFF
--- a/deploy/health-checks/active-directory/New-AzureLogAnalyticsWorkspace.ps1
+++ b/deploy/health-checks/active-directory/New-AzureLogAnalyticsWorkspace.ps1
@@ -3,7 +3,7 @@ param(
     $ResourceGroupName = "active-directory-health-rg",
     $WorkspaceName = "active-directory-health-" + (Get-Random -Maximum 99999), # workspace names need to be unique - Get-Random helps with this for the example code
     $Location = "westeurope",
-    $Sku = 'Standard'
+    $Sku = 'standalone'
 )
 <#
 
@@ -44,11 +44,11 @@ Set-AzContext -SubscriptionId $subscriptionId
 # Create the resource group if needed
 try {
 
-    Get-AzResourceGroup -Name $ResourceGroup -ErrorAction Stop
+    Get-AzResourceGroup -Name $ResourceGroupName -ErrorAction Stop
 
 } catch {
 
-    New-AzResourceGroup -Name $ResourceGroup -Location $Location
+    New-AzResourceGroup -Name $ResourceGroupName -Location $Location
 
 }
 
@@ -56,10 +56,13 @@ try {
 
 $WorkspaceParameters = @{
     Name = $WorkspaceName
-    RetentionInDays = 90
     Location = $Location
     ResourceGroupName = $ResourceGroupName
     Sku = $Sku
+}
+
+if ($Sku -eq 'standalone') {
+    $WorkspaceParameters.Add('RetentionInDays',90)
 }
 
 New-AzOperationalInsightsWorkspace @WorkspaceParameters


### PR DESCRIPTION
## PR Summary

- Fixed variable $ResourceGroupName
- Fixed logic for configuring data retention, as this is only possible when using the standalone/Per GB SKU

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [NA] PR has tests
- [NA] Markdown documentation created
- [NA] PR has new or removed features in `deploy\` and I have updated `deploy\PlasterManifest.xml`
- [x] This PR is ready to merge and is not work in progress
